### PR TITLE
refactor: take connection in `WebSocket::{manage, manage_with_timeout}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ async fn handle_websocket(
         &req.headers["Sec-WebSocket-Key"]
     );
 
-    let (sign, ws) = ctx.upgrade(tcp,
+    let (sign, ws) = ctx.on_upgrade(
         |mut conn: Connection| async move {
             while let Ok(Some(Message::Text(text))) = conn.recv().await {
                 conn.send(text).await
@@ -53,7 +53,7 @@ async fn handle_websocket(
         }
     );
 
-    spawn(ws.manage());
+    spawn(ws.manage(tcp));
 
     /* return `Switching Protocol` response with `sign`... */
 }


### PR DESCRIPTION
- Remove field `conn: C` from `WebSocket<C>`
- Change to take `conn: C` as an argument of `WebSocket::{manage, manage_with_timeout}`
- Set default type for `C` of `split::{ReadHalf<C>, WriteHalf}` to `<runtime::TcpStream as Splitable<'static>>::{ReadHalf, WriteHalf}`

for usage convention of other crates