### PR TITLE
fix `split`: use `try_read` to detect already-closed

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -444,12 +444,7 @@ pub mod split {
         /// 
         /// This panics if the original `Connection` is already closed.
         pub fn split(self) -> (ReadHalf<C::ReadHalf>, WriteHalf<C::WriteHalf>) {
-            #[cfg(feature="glommio")]
-            if !matches!(Arc::into_inner(self.__closed__).map(RwLock::into_inner), Some(Ok(false))) {
-                panic!("{ALREADY_CLOSED_MESSAGE}")
-            }
-            #[cfg(not(feature="glommio"))]
-            if Arc::into_inner(self.__closed__).map(RwLock::into_inner) != Some(false) {
+            if !(*self.__closed__.try_read().expect(ALREADY_CLOSED_MESSAGE) == false) {
                 panic!("{ALREADY_CLOSED_MESSAGE}")
             }
 


### PR DESCRIPTION
Before used `Arc::into_inner(self).map(RwLock::into_inner)` here, but `Arc::into_inner` always returns `None` in the expected situations because corresponded `Closer` shares the `Arc`.
This PR fixes this to use `RwLock::try_read`. This read is expected to success in right usage of `split`.