### PR TITLE
chore: remove `nio` and `async-std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ features = ["rt_tokio"]
 
 [dependencies]
 tokio     = { optional = true, version = "1", features = ["net", "io-util", "sync", "time"] }
-async-std = { optional = true, version = "1"   }
 smol      = { optional = true, version = "2"   }
-nio       = { optional = true, version = "0.0" }
 glommio   = { optional = true, version = "0.9" }
 
 futures-util = { optional = true, version = "0.3", default-features = false, features = ["io"] }
@@ -29,9 +27,7 @@ base64 = { version = "0.22" }
 
 [features]
 rt_tokio     = ["__splitref__", "dep:tokio","tokio/net","tokio/io-util","tokio/sync","tokio/time"]
-rt_async-std = ["__clone__",    "dep:async-std"]
 rt_smol      = ["__clone__",    "dep:smol"]
-rt_nio       = ["__splitref__", "dep:nio",     "dep:tokio","tokio/io-util"]
 rt_glommio   = ["__splitref__", "dep:glommio", "dep:futures-util"]
 
 ### internal ###

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 * Minimal and Efficient : minimal codebase to provide efficient, memory-safe WebSocket handling.
 
-* Multi Environment : `tokio`, `async-std`, `smol`, `nio`, `glommio` are supported as async runtime ( by feature flags `rt_{name}` ).
+* Multi Environment : `tokio`, `smol`, `glommio` are supported as async runtime ( by feature flags `rt_{name}` ).
 
 ## Note
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,7 +3,7 @@ version: 3
 tasks:
   CI:
     deps:
-      - for:  [tokio, async-std, smol, nio, glommio]
+      - for:  [tokio, smol, glommio]
         task: test:rt
         vars: { rt: '{{.ITEM}}' }
       - task: test:no_rt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! 
 //! * Minimal and Efficient : minimal codebase to provide efficient, memory-safe WebSocket handling.
 //! 
-//! * Multiple Environment : `tokio`, `async-std`, `smol`, `nio`, `glommio` are supported as async runtime ( by feature flags `rt_{name}` ).
+//! * Multiple Environment : `tokio`, `smol`, `glommio` are supported as async runtime ( by feature flags `rt_{name}` ).
 //! 
 //! ## Note
 //! 
@@ -26,11 +26,9 @@
 //! * Doesn't builtins `wss://` support.
 
 #[cfg(any(
-    all(feature="rt_tokio",     any(feature="rt_async-std", feature="rt_smol",      feature="rt_nio",       feature="rt_glommio"  )),
-    all(feature="rt_async-std", any(feature="rt_smol",      feature="rt_nio",       feature="rt_glommio",   feature="rt_tokio"    )),
-    all(feature="rt_smol",      any(feature="rt_nio",       feature="rt_glommio",   feature="rt_tokio",     feature="rt_async-std")),
-    all(feature="rt_nio",       any(feature="rt_glommio",   feature="rt_tokio",     feature="rt_async-std", feature="rt_smol"     )),
-    all(feature="rt_glommio",   any(feature="rt_tokio",     feature="rt_async-std", feature="rt_smol",      feature="rt_nio"      )),
+    all(feature="rt_tokio",   any(feature="rt_smol",    feature="rt_glommio")),
+    all(feature="rt_smol",    any(feature="rt_glommio", feature="rt_tokio"  )),
+    all(feature="rt_glommio", any(feature="rt_tokio",   feature="rt_smol"   )),
 ))]
 compile_error! {"More than one runtime feature flags can't be activated"}
 
@@ -45,15 +43,6 @@ mod runtime {
         tokio::time::sleep
     };
 
-    #[cfg(feature="rt_async-std")]
-    pub use {
-        async_std::net::TcpStream,
-        async_std::io::ReadExt as AsyncRead,
-        async_std::io::WriteExt as AsyncWrite,
-        async_std::sync::RwLock,
-        async_std::task::sleep
-    };
-
     #[cfg(feature="rt_smol")]
     pub use {
         smol::net::TcpStream,
@@ -65,15 +54,6 @@ mod runtime {
     pub async fn sleep(duration: std::time::Duration) {
         smol::Timer::after(duration).await;
     }
-
-    #[cfg(feature="rt_nio")]
-    pub use {
-        nio::net::TcpStream,
-        tokio::io::AsyncReadExt as AsyncRead,
-        tokio::io::AsyncWriteExt as AsyncWrite,
-        tokio::sync::RwLock,
-        nio::time::sleep
-    };
 
     #[cfg(feature="rt_glommio")]
     pub use {


### PR DESCRIPTION
- [`async-std`](https://github.com/async-rs/async-std): not maintained
- [`nio`](https://github.com/nurmohammed840/nio): seems not actively maintained now (see https://github.com/nurmohammed840/nio/issues/5)

(`nio` may be restored in future depending on its maintenance status)