### PR TITLE
feat: `tcpstream-only`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,13 @@ sha1   = { version = "0.10", default-features = false }
 base64 = { version = "0.22" }
 
 [features]
-rt_tokio     = ["__runtime__", "dep:tokio", "futures-util/unstable","futures-util/bilock"]
-rt_smol      = ["__runtime__", "dep:smol"]
-rt_glommio   = ["__runtime__", "dep:glommio"]
+### runtimes ###
+rt_tokio   = ["__runtime__", "dep:tokio", "futures-util/unstable","futures-util/bilock"]
+rt_smol    = ["__runtime__", "dep:smol"]
+rt_glommio = ["__runtime__", "dep:glommio"]
+
+### optimizations ###
+tcpstream-only = []
 
 ### internal ###
 __runtime__  = []

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ MEWS is NOT WebSocket server, just protocol implementation. So :
 
 * Doesn't builtins `wss://` support.
 
+## Feature Flags
+
+- `tcpstream-only` : limit `split` functionality to only the runtime's `TcpStream`, in exchange for possible performance optimization.
+
 ## Example
 
 ```toml

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -12,6 +12,7 @@ tasks:
   test:rt:
     cmds:
       - cargo test --lib --features rt_{{.rt}}
+      - cargo test --lib --features rt_{{.rt}},tcpstream-only
 
   test:no_rt:
     cmds:

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -343,8 +343,21 @@ pub mod split {
             }
         }
     };
-
+    
     #[cfg(any(feature="rt_tokio"))]
+    #[cfg(feature="tcpstream-only")]
+    const _: (/* tokio::net::TcpStream users */) = {
+        /* efficient-able specialized impl for `tokio::net::TcpStream` */
+        impl<'split> Splitable<'split> for tokio::net::TcpStream {
+            type ReadHalf  = tokio::net::tcp::ReadHalf<'split>;
+            type WriteHalf = tokio::net::tcp::WriteHalf<'split>;
+            fn split(&'split mut self) -> (Self::ReadHalf, Self::WriteHalf) {
+                tokio::net::TcpStream::split(self)
+            }
+        }
+    };
+    #[cfg(any(feature="rt_tokio"))]
+    #[cfg(not(feature="tcpstream-only"))]
     const _: (/* tokio::io users */) = {
         impl<'split, T: AsyncRead + AsyncWrite + Unpin + 'split> Splitable<'split> for T {
             type ReadHalf  = TokioIoReadHalf<'split, T>;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -335,6 +335,15 @@ pub mod split {
 
     #[cfg(any(feature="rt_smol", feature="rt_glommio"))]
     const _: (/* futures-io users */) = {
+        #[cfg(feature="tcpstream-only")]
+        impl<'split> Splitable<'split> for crate::runtime::net::TcpStream {
+            type ReadHalf  = futures_util::io::ReadHalf<&'split mut Self>;
+            type WriteHalf = futures_util::io::WriteHalf<&'split mut Self>;
+            fn split(&'split mut self) -> (Self::ReadHalf, Self::WriteHalf) {
+                AsyncRead::split(self)
+            }
+        }
+        #[cfg(not(feature="tcpstream-only"))]
         impl<'split, T: AsyncRead + AsyncWrite + Unpin + 'split> Splitable<'split> for T {
             type ReadHalf  = futures_util::io::ReadHalf<&'split mut T>;
             type WriteHalf = futures_util::io::WriteHalf<&'split mut T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ mod runtime {
         tokio::sync::RwLock,
         tokio::time::sleep
     };
-    #[cfg(test)]
+    #[cfg(any(test, feature="tcpstream-only"))]
     pub use tokio::net;
 }
 #[cfg(feature="rt_smol")]
@@ -53,7 +53,7 @@ mod runtime {
     pub async fn sleep(duration: std::time::Duration) {
         smol::Timer::after(duration).await;
     }
-    #[cfg(test)]
+    #[cfg(any(test, feature="tcpstream-only"))]
     pub use smol::net;
 }
 #[cfg(feature="rt_glommio")]
@@ -64,7 +64,7 @@ mod runtime {
         glommio::sync::RwLock,
         glommio::timer::sleep
     };
-    #[cfg(test)]
+    #[cfg(any(test, feature="tcpstream-only"))]
     pub use glommio::net;
 }
 


### PR DESCRIPTION
Adding `tcpstream-only` feature flag: when it's activated, limit `split` functionality to only the runtime's `TcpStream`, in exchange for possible performance optimization by using `tokio::net::TcpStream::split` for `Splitable` impl instead of generic impl by the `futures_util::locK::BiLock` wrappers.