### PR TITLE
expose somethings without requireing `io_*` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ mod sync {
     pub(crate) use tokio::sync::RwLock;
 }
 
-#[cfg(feature="__io__")]
 pub mod message;
 #[cfg(feature="__io__")]
 pub mod frame;
@@ -47,9 +46,9 @@ pub mod websocket;
 #[cfg(feature="__io__")]
 pub mod connection;
 
+pub use message::{Message, CloseFrame, CloseCode};
 #[cfg(feature="__io__")]
 pub use {
-    message::{Message, CloseFrame, CloseCode},
     websocket::*,
     connection::{Connection, split::{self, Splitable, ReadHalf, WriteHalf}},
 };

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,8 +1,10 @@
-#![cfg(feature="__io__")]
-use crate::frame::{Frame, OpCode};
-use crate::io::{AsyncRead, AsyncWrite};
-use crate::Config;
-use std::io::{Error, ErrorKind};
+#[cfg(feature="__io__")]
+use {
+    crate::io::{AsyncRead, AsyncWrite},
+    crate::frame::{Frame, OpCode},
+    crate::Config,
+    std::io::{Error, ErrorKind},
+};
 
 #[derive(Debug)]
 pub enum Message {


### PR DESCRIPTION
expose `Message`, `CloseCode`, `CloseFrame` without requiring `io_*` feature